### PR TITLE
Cambio de autenticación a OAuth para usar la cuenta de unizar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ poetry.lock
 
 # Archivos secretos
 scripts/credentials.json
+scripts/client_secret.json
+scripts/token.json
 
 # Archivos comprimidos
 *.zip

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 from flask import Flask, render_template, session, request, redirect, url_for
 import secrets
 import datetime
+import os
 import scripts.api
+from google_auth_oauthlib.flow import Flow
 
 import qrcode
 from io import BytesIO
@@ -12,6 +14,42 @@ from scripts.calculo_de_probabilidad import *
 app = Flask(__name__)
 app.secret_key = b'%s' % secrets.token_bytes()
 app.config['PERMANENT_SESSION_LIFETIME'] = datetime.timedelta(minutes=60)
+
+# Cliente OAuth (tipo "Web application") descargado de Google Cloud Console.
+CLIENT_SECRETS_FILE = os.path.join(os.path.dirname(__file__), "scripts", "client_secret.json")
+# Debe coincidir EXACTAMENTE con un URI de redirección autorizado en Cloud Console.
+OAUTH_REDIRECT_URI = os.environ.get("OAUTH_REDIRECT_URI", "http://127.0.0.1:5000/oauth2callback")
+
+def _build_oauth_flow(state=None):
+    return Flow.from_client_secrets_file(
+        CLIENT_SECRETS_FILE,
+        scopes=scripts.api.SCOPES,
+        state=state,
+        redirect_uri=OAUTH_REDIRECT_URI,
+    )
+
+@app.route('/authorize')
+def authorize():
+    """Punto de entrada para que la cuenta unizar.es conceda acceso a su Drive/Forms."""
+    flow = _build_oauth_flow()
+    authorization_url, state = flow.authorization_url(
+        access_type='offline',
+        include_granted_scopes='true',
+        prompt='consent',
+    )
+    session['oauth_state'] = state
+    return redirect(authorization_url)
+
+@app.route('/oauth2callback')
+def oauth2callback():
+    flow = _build_oauth_flow(state=session.get('oauth_state'))
+    flow.fetch_token(authorization_response=request.url)
+
+    creds = flow.credentials
+    with open(scripts.api.TOKEN_PATH, 'w') as f:
+        f.write(creds.to_json())
+
+    return "Autorización completada. Ya puede volver a la aplicación y usar el formulario de Google."
 
 @app.route('/')
 def index():
@@ -48,19 +86,25 @@ def delete_player():
 
 @app.route('/get-players-from-form')
 def get_players_from_form():
-    form_id, form_url = scripts.api.crear_formulario()
+    try:
+        form_id, form_url = scripts.api.crear_formulario()
+    except scripts.api.NoAutorizado:
+        return redirect(url_for('authorize'))
 
     qr_img = qrcode.make(form_url)
     buffer = BytesIO()
     qr_img.save(buffer, format="PNG")
 
     qr_base64 = base64.b64encode(buffer.getvalue()).decode("utf-8")
-    
+
     return render_template('get-players-from-form.html',qr_code=qr_base64, form_id=form_id)
 
 @app.route('/extract-players', methods=['GET'])
 def extract_players():
-    players = scripts.api.obtener_respuestas(request.args.get('form_id'))
+    try:
+        players = scripts.api.obtener_respuestas(request.args.get('form_id'))
+    except scripts.api.NoAutorizado:
+        return redirect(url_for('authorize'))
     session['players'] = players
     return redirect(url_for('index'))
 

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -1,32 +1,54 @@
 from googleapiclient.discovery import build
-from oauth2client.service_account import ServiceAccountCredentials
-import time, sys, os
+from google.oauth2.credentials import Credentials
+from google.auth.transport.requests import Request
+import sys, os
 
-import gspread
-from oauth2client.service_account import ServiceAccountCredentials
-
-# Autenticación con la cuenta de servicio
+# Autenticación por consentimiento OAuth (la cuenta unizar.es concede acceso
+# a su propio Drive una única vez a través de /authorize en la app Flask).
 SCOPES = [
     "https://www.googleapis.com/auth/forms.body",
     "https://www.googleapis.com/auth/forms.responses.readonly",
     "https://www.googleapis.com/auth/drive"
 ]
 
-try:
-    creds = ServiceAccountCredentials.from_json_keyfile_name("scripts/credentials.json", SCOPES)
-except FileNotFoundError:
-    print("Error de autenticación. Compruebe que el archivo credentials.json está en el directorio scrpits. Si el error persiste, contacte con matemanicos@unizar.es .")
-    sys.exit()
+TOKEN_PATH = os.path.join(os.path.dirname(__file__), "token.json")
 
-# Conectar con la API de Drive y Forms
-drive_service = build("drive", "v3", credentials=creds)
-forms_service = build("forms", "v1", credentials=creds)
+
+class NoAutorizado(Exception):
+    """Se lanza cuando todavía no se ha concedido acceso vía /authorize."""
+
+
+def _load_credentials():
+    if not os.path.exists(TOKEN_PATH):
+        return None
+
+    creds = Credentials.from_authorized_user_file(TOKEN_PATH, SCOPES)
+    if creds and creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        with open(TOKEN_PATH, "w") as f:
+            f.write(creds.to_json())
+    return creds
+
+
+def get_services():
+    """Construye los clientes de Drive y Forms a partir del token guardado."""
+    creds = _load_credentials()
+    if not creds or not creds.valid:
+        raise NoAutorizado(
+            "No hay credenciales válidas. Visite /authorize para conceder acceso "
+            "a Google Drive/Forms con su cuenta de unizar.es."
+        )
+    drive_service = build("drive", "v3", credentials=creds)
+    forms_service = build("forms", "v1", credentials=creds)
+    return drive_service, forms_service
 
 def crear_formulario():
     """Crea el formulario para introducir participantes."""
+    _, forms_service = get_services()
+
     form_metadata = {"info": {"title": "Sorteo por apellidos"}}
     form = forms_service.forms().create(body=form_metadata).execute()
-    
+
     preguntas = {
         "requests": [
             {"createItem": {"item": {"title": "Nombre", "questionItem": {"question": {"required": True, "textQuestion": {}}}}, "location": {"index": 0}}},
@@ -40,6 +62,7 @@ def crear_formulario():
 
 def eliminar_formulario(form_id):
     """Elimina el formulario de Google Drive."""
+    drive_service, _ = get_services()
     drive_service.files().delete(fileId=form_id).execute()
     print("Formulario eliminado.\n")
 
@@ -49,6 +72,7 @@ def obtener_respuestas(form_id):
     correcta nombre / apellido1 / apellido2 utilizando los títulos de
     las preguntas del propio formulario como fuente de verdad.
     """
+    _, forms_service = get_services()
     participantes = []
 
     # 1) Obtener la estructura del formulario para mapear questionId -> título


### PR DESCRIPTION
…sent

Add /authorize and /oauth2callback routes so a unizar.es account grants access to its own Drive once; the token is stored and auto-refreshed in scripts/token.json instead of using a service account key.