### PR TITLE
Publish forms for public responses and pin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Flask==3.1.2
+google-api-python-client==2.198.0
+google-auth==2.38.0
+google-auth-httplib2==0.2.0
+google-auth-oauthlib==1.2.1
+qrcode==8.2
+Pillow==11.3.0
+Unidecode==1.4.0

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -44,7 +44,7 @@ def get_services():
 
 def crear_formulario():
     """Crea el formulario para introducir participantes."""
-    _, forms_service = get_services()
+    drive_service, forms_service = get_services()
 
     form_metadata = {"info": {"title": "Sorteo por apellidos"}}
     form = forms_service.forms().create(body=form_metadata).execute()
@@ -57,6 +57,18 @@ def crear_formulario():
         ]
     }
     forms_service.forms().batchUpdate(formId=form["formId"], body=preguntas).execute()
+
+    # Publicar el formulario y compartirlo con "cualquiera con el enlace" para
+    # que pueda responder aunque no pertenezca a la organización unizar.es.
+    forms_service.forms().setPublishSettings(
+        formId=form["formId"],
+        body={"publishSettings": {"publishState": {"isPublished": True, "isAcceptingResponses": True}}}
+    ).execute()
+    drive_service.permissions().create(
+        fileId=form["formId"],
+        body={"type": "anyone", "view": "published", "role": "reader"}
+    ).execute()
+
     print("Formulario creado:", form["responderUri"])
     return form["formId"], form["responderUri"]
 


### PR DESCRIPTION
Publish each created form and share it with anyone-with-the-link so respondents outside the unizar.es org can fill it in, using the Forms API's setPublishSettings plus a Drive "anyone" reader permission. Add requirements.txt pinning the versions this depends on (newer google-api-python-client is required for setPublishSettings support).